### PR TITLE
Remove /api from the url path in the code

### DIFF
--- a/backend/api_reports.py
+++ b/backend/api_reports.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, jsonify, render_template, abort, request
 
-api_reports = Blueprint('api_reports', __name__, url_prefix='/api/reports')
+api_reports = Blueprint('api_reports', __name__, url_prefix='/reports')
 
 REPORT_TYPES = [
     {


### PR DESCRIPTION
Zrobiłem, że cały backend powinien być dostępny pod https://smartcmms.everest.stream/api, więc teraz endpoint od raportów wygląda tak: https://smartcmms.everest.stream/api/api/reports.
W miejscu https://smartcmms.everest.stream pojawił się frontend.

I ta zmiana usuwa to niepotrzebne jedno /api z urla